### PR TITLE
changed Xfree to XDestroyImage in xserver-screen.cc to fix a memory leak

### DIFF
--- a/xserver-screen.cc
+++ b/xserver-screen.cc
@@ -94,7 +94,7 @@ int ShowScreen(Display *display, size_t x, size_t y, size_t width, size_t height
         }
 
         offscreen_canvas = matrix->SwapOnVSync(offscreen_canvas);
-        XFree(img);
+        XDestroyImage(img);
         usleep(UPDATE_INTERVAL);
     }
 


### PR DESCRIPTION
This relates to Issue #1 -- See https://stackoverflow.com/questions/47543964/memory-leak-when-using-x11-xutil-h-library-to-read-pixels-with-valgrind-outpu for details about the fix. Was able to confirm that the solution does indeed appear to resolve the memory leak. 